### PR TITLE
Changed Ingalls award order to ascending

### DIFF
--- a/about.html
+++ b/about.html
@@ -53,9 +53,9 @@
           <h4>Past recipients of the Dr. Robert P. Ingalls award:</h4>
             <p>
               <ul>
-                <li>2010 - Robert Escriva</li>
-                <li>2009 - John E. Lazos</li>
                 <li>2008 - Suzanne J. Matthews</li>
+                <li>2009 - John E. Lazos</li>
+                <li>2010 - Robert Escriva</li>
                 <li>2015 - Josh Goldberg</li>
               </ul>
             </p>


### PR DESCRIPTION
For some reason, it was '10, '9, '8, '15. What's going on here.